### PR TITLE
python3 compatibility update

### DIFF
--- a/dlcs/__init__.py
+++ b/dlcs/__init__.py
@@ -1,3 +1,3 @@
-from image_collection import Image, ImageCollection
-import client
-from queue_response import Batch
+from dlcs.image_collection import Image, ImageCollection
+import dlcs.client
+from dlcs.queue_response import Batch

--- a/dlcs/image_collection.py
+++ b/dlcs/image_collection.py
@@ -65,7 +65,7 @@ class ImageCollection(JSONLDBaseWithHydraContext):
     def to_json_dict(self):
 
         data = super(ImageCollection, self).to_json_dict()
-        add_if_not_none(data, 'member', map(lambda x: x.to_json_dict(), self.members))
+        add_if_not_none(data, 'member', list(map(lambda x: x.to_json_dict(), self.members)))
         add_if_not_none(data, 'total_items', self.total_items)
 
         return data


### PR DESCRIPTION
- used absolute imports, because the syntax is compatible with both py2  and py3.
- python3 map function outputs an iterable, needed to convert to a list. (which will be still valid in py2) 